### PR TITLE
Add `main` field so npm version works

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "bugs": {
     "web": "https://github.com/Rich-Harris/Simulant/issues"
   },
+  "main": "simulant.js",
   "jam": {
     "main": "simulant.js",
     "include": [


### PR DESCRIPTION
Trying to install/use this with browserify fails without this field. 

I dig the tool though, thanks for sharing!
