### PR TITLE
Fix extendWithKeyboardParams in legacy mode

### DIFF
--- a/src/utils/extendWithKeyboardParams.js
+++ b/src/utils/extendWithKeyboardParams.js
@@ -1,6 +1,6 @@
-const keyboardParams = [ 'which', 'keyCode', 'shiftKey', 'ctrlKey', 'altKey', 'metaKey' ];
+const keyboardParams = [ 'altKey', 'charCode', 'code', 'ctrlKey', 'isComposing', 'key', 'keyCode', 'keyIdentifier', 'location', 'metaKey', 'repeat', 'shiftKey', 'which' ];
 
-export default function extendWithKeyboardParams ( event, params ) {
+export default function extendWithKeyboardParams ( event, params = {} ) {
 	let i = keyboardParams.length;
 	while ( i-- ) {
 		event[ keyboardParams[i] ] = params[ keyboardParams[i] ];


### PR DESCRIPTION
Fixes two bugs with this setup:

`simulant@0.2.0`
`phantomjs-prebuilt@2.1.7`
`console.log(simulant.mode) //=> 'legacy'`

## Bug 1

`simulant.fire()` with no params argument throws with the above setup.

**Try**

```js
simulant.fire(document, 'keydown')
// works: simulant.fire(document, 'keydown', {})
```

```shell
undefined is not an object (evaluating 'params[keyboardParams[i]]')

at extendWithKeyboardParams   ~/simulant/dist/simulant.es.js:121:36
at simulant                   ~/simulant/dist/simulant.es.js:216:28
at fire                       ~/simulant/dist/simulant.es.js:367:20
```

**Fix**

Use default `params = {}`:

```diff
- function extendWithKeyboardParams(event, params) {
+ function extendWithKeyboardParams(event, params = {}) {
  var i = keyboardParams.length;
  while (i--) {
    event[keyboardParams[i]] = params[keyboardParams[i]];
  }
}
```

## Bug 2

`code` is a valid [KeyboardEvent property](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Properties), but it is not included in the list of [keyboardParams](https://github.com/Rich-Harris/simulant/blob/master/src/utils/extendWithKeyboardParams.js#L1) that the event is extended with.  So, it is missing in the returned event.

**Try**

```js
const evt = simulant('keydown', { code: 'Escape' })
console.log(evt.code)
//=> undefined
// expected 'Escape'
```

**Fix**

Add all `KeyboardEvent` properties (deprecated and working draft) to the list of params.

```diff
- var keyboardParams = ['which', 'keyCode', 'shiftKey', 'ctrlKey', 'altKey', 'metaKey'];
+ var keyboardParams = [ 'altKey', 'charCode', 'code', 'ctrlKey', 'isComposing', 'key', 'keyCode', 'keyIdentifier', 'location', 'metaKey', 'repeat', 'shiftKey', 'which' ];
function extendWithKeyboardParams(event, params) {
  var i = keyboardParams.length;
```