### PR TITLE
Support initializer params for touch events

### DIFF
--- a/src/maps.js
+++ b/src/maps.js
@@ -87,6 +87,7 @@ Object.keys( eventTypesByGroup ).forEach( group => {
 export var initialiserParams = {
 	initUIEvent:          'view detail',
 	initMouseEvent:       'view detail screenX screenY clientX clientY ctrlKey altKey shiftKey metaKey button relatedTarget',
+	initTouchEvent:       'view detail touches targetTouches changedTouches ctrlKey altKey shiftKey metaKey',
 	initCompositionEvent: 'view detail data locale',
 	initHashChangeEvent:  'oldURL newURL',
 	initMessageEvent:     'data origin lastEventId source ports',
@@ -115,4 +116,3 @@ export var initialisersByGroup = {
 	TouchEvent:          [ window.TouchEvent,          'initTouchEvent'       ],
 	WheelEvent:          [ window.WheelEvent,          'initWheelEvent'       ] // TODO this differs between browsers...
 };
-

--- a/test/tests.js
+++ b/test/tests.js
@@ -117,6 +117,8 @@ it( 'blurs an input', function () {
 it( 'fires beforeunload (#6)', function () {
 	expect( 1 );
 
+	var called = false;
+
 	function handler () {
 		called = true;
 	}
@@ -128,3 +130,23 @@ it( 'fires beforeunload (#6)', function () {
 
 	window.removeEventListener( 'beforeunload', handler );
 });
+
+if (typeof window.Touch === 'function') {
+	it( 'uses the correct initializer params for touch events', function () {
+		expect( 2 );
+
+		var called = false;
+		var hasTouches = false;
+
+		el.addEventListener('touchstart', function (event) {
+			called = true;
+			hasTouches = event.touches.length > 0;
+		});
+
+		simulant.fire(el, 'touchstart', {
+			touches: [new Touch({identifier: 0, target: el})]
+		});
+		assert.ok(called);
+		assert.ok(hasTouches);
+	});
+}


### PR DESCRIPTION
This commit adds support for passing initializer parameters to touch
events, as outlined at
https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent
