### PR TITLE
Set nightmare dev-dependency to use 2.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "chalk": "^1.1.3",
     "eslint": "^2.8.0",
-    "nightmare": "^2.3.4",
+    "nightmare": "~2.8.1",
     "rollup": "^0.26.0",
     "rollup-plugin-buble": "^0.7.0"
   },


### PR DESCRIPTION
segmentio/nightmare#825 broke being able to set beforeonload events, which was causing the test failure shown in Travis-CI in #20.

See segmentio/nightmare#1082 for explanation.